### PR TITLE
Fix question number

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
                 "{}{}{}/{} 問題：{}{}",
                 color::Fg(color::Cyan),
                 style::Bold,
-                count,
+                count + 1,
                 length,
                 subject.question,
                 style::Reset


### PR DESCRIPTION
Sorry about this 🙏 

After using `enumerate()`, the count number will start from `0` instead of `1`.
So, we can add `1` while passing it to `println!`, thanks!