### PR TITLE
refactor: group imports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io;
+
+use serde::{Deserialize, Serialize};
 use termion::{color, style};
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Personally I love Python PEP8 import order rules:

1. Standard library imports.
2. Related third party imports.
3. Local application/library specific imports.

_And put a blank line between each group of imports._

Feel free to accept or reject this commit.